### PR TITLE
Add contract to should() for smart-casting nullable values

### DIFF
--- a/src/commonMain/kotlin/Assertions.kt
+++ b/src/commonMain/kotlin/Assertions.kt
@@ -36,6 +36,7 @@ public fun assert(actual: Boolean, message: String? = null) {
 public infix fun <T> T?.should(block: T.() -> Unit) {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        returns() implies (this@should != null)
     }
     assertNotNull(this)
     block()

--- a/src/commonTest/kotlin/AssertionsTest.kt
+++ b/src/commonTest/kotlin/AssertionsTest.kt
@@ -225,4 +225,22 @@ class AssertionsTest {
         )
     }
 
+    @Test
+    fun `should smart cast nullable value to non-null after should block`() {
+        @Suppress("RedundantNullableReturnType") // we need it for test
+        val nullableMessage: Message? = message
+
+        nullableMessage should {
+            have(id == 42)
+        }
+
+        // This should compile without null check due to the contract
+        // If the contract doesn't work, this line would require nullableMessage?.id or !!
+        val messageId = nullableMessage.id
+        assertEquals(42, messageId)
+
+        // Also test that we can access properties directly
+        assertEquals(2, nullableMessage.content.size)
+    }
+
 }


### PR DESCRIPTION
Enhanced the `should` function with a contract that ensures smart-casting of nullable values to non-null after the should block returns successfully. This allows direct property access without null checks after validation.

Added test to verify the smart-cast behavior works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)