### PR TITLE
Add truncation for large diffs in sameAs assertion

### DIFF
--- a/src/commonTest/kotlin/SameAsTest.kt
+++ b/src/commonTest/kotlin/SameAsTest.kt
@@ -34,9 +34,13 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference on different single line strings`() {
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             "foo" sameAs "bar"
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -66,9 +70,13 @@ class SameAsTest {
             
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,4 +1,3 @@
@@ -83,9 +91,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with whitespace differences`() {
-        assertFailsWith<AssertionError> {
-            "line1\nline2\t\n" sameAs "line1\n line2 \n"
-        }.message sameAs """
+        // given
+        val expected = "line1\n line2 \n"
+        val actual = "line1\nline2\t\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,2 +1,2 @@
@@ -98,9 +114,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with addition at beginning`() {
-        assertFailsWith<AssertionError> {
-            "line1\nline2\n" sameAs "new line\nline1\nline2\n"
-        }.message sameAs """
+        // given
+        val expected = "new line\nline1\nline2\n"
+        val actual = "line1\nline2\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+             actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,3 +1,2 @@
@@ -113,9 +137,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with addition at end`() {
-        assertFailsWith<AssertionError> {
-            "line1\nline2\nline3" sameAs "line1\nline2"
-        }.message sameAs """
+        // given
+        val expected = "line1\nline2"
+        val actual = "line1\nline2\nline3"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,2 +1,3 @@
@@ -145,9 +177,13 @@ class SameAsTest {
             }
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,4 +1,3 @@
@@ -162,6 +198,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with portuguese text changes from java-diff-utils one-delta-test`() {
+        // given
         val expected = """
             Esta é uma obra Online.
             
@@ -207,9 +244,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,19 +1,18 @@
@@ -247,6 +288,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with database schema changes from java-diff-utils issue15`() {
+        // given
         val expected = """
             TABLE_NAME, COLUMN_NAME, DATA_TYPE, DATA_LENGTH, DATA_PRECISION, NULLABLE,
             ACTIONS_C17005, ID, NUMBER, 22, 19, N,
@@ -271,9 +313,13 @@ class SameAsTest {
             ACTIONS_C16913, HOURS_SPENT, VARCHAR2, 255, null, Y,
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,9 +1,9 @@
@@ -302,9 +348,13 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference when comparing empty string with non-empty`() {
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             "content" sameAs ""
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -0,0 +1 @@
@@ -316,9 +366,13 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference when comparing non-empty string with empty`() {
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             "" sameAs "content"
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +0,0 @@
@@ -330,6 +384,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with pure deletion in middle`() {
+        // given
         val expected = """
             line1
             line2
@@ -346,9 +401,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,5 +1,3 @@
@@ -363,9 +422,13 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with single trailing newline difference`() {
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             "line\n" sameAs "line"
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -378,9 +441,13 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference when removing trailing newline`() {
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             "line" sameAs "line\n"
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -402,6 +469,7 @@ class SameAsTest {
      */
     @Test
     fun `should fail and report difference with classic lao-tzu example from GNU diffutils manual`() {
+        // given
         val lao = """
             The Way that can be told of is not the eternal Way;
             The name that can be named is not the eternal name.
@@ -434,9 +502,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             tzu sameAs lao
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,7 +1,6 @@
@@ -462,23 +534,47 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with multiple consecutive blank lines`() {
-        assertFailsWith<AssertionError> {
-            "line1\n\n\nline2\n" sameAs "line1\n\nline2\n"
-        }.message sameAs "--- expected\n+++ actual\n@@ -1,3 +1,4 @@\n line1\n \n+\n line2\n"
+        // given
+        val expected = "line1\n\nline2\n"
+        val actual = "line1\n\n\nline2\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs "--- expected\n+++ actual\n@@ -1,3 +1,4 @@\n line1\n \n+\n line2\n"
     }
 
     @Test
     fun `should fail and report difference with only whitespace differences`() {
-        assertFailsWith<AssertionError> {
-            "   " sameAs "\t"
-        }.message sameAs "--- expected\n+++ actual\n@@ -1 +1 @@\n-\t\n\\ No newline at end of file\n+   \n\\ No newline at end of file\n"
+        // given
+        val expected = "\t"
+        val actual = "   "
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs "--- expected\n+++ actual\n@@ -1 +1 @@\n-\t\n\\ No newline at end of file\n+   \n\\ No newline at end of file\n"
     }
 
     @Test
     fun `should fail and report difference with unicode and emoji characters`() {
-        assertFailsWith<AssertionError> {
-            "Hello 👋" sameAs "Hello 🌍"
-        }.message sameAs """
+        // given
+        val expected = "Hello 🌍"
+        val actual = "Hello 👋"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -492,9 +588,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with unicode text changes`() {
-        assertFailsWith<AssertionError> {
-            "Привет мир\nこんにちは世界\n" sameAs "Hello world\nこんにちは世界\n"
-        }.message sameAs """
+        // given
+        val expected = "Hello world\nこんにちは世界\n"
+        val actual = "Привет мир\nこんにちは世界\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,2 +1,2 @@
@@ -507,6 +611,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with large context distance`() {
+        // given
         val expected = """
             line1
             line2
@@ -555,9 +660,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,4 +1,4 @@
@@ -581,9 +690,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference when all lines are changed`() {
-        assertFailsWith<AssertionError> {
-            "alpha\nbeta\ngamma\n" sameAs "one\ntwo\nthree\n"
-        }.message sameAs """
+        // given
+        val expected = "one\ntwo\nthree\n"
+        val actual = "alpha\nbeta\ngamma\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,3 +1,3 @@
@@ -599,6 +716,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with alternating line changes`() {
+        // given
         val expected = """
             keep1
             change1
@@ -621,9 +739,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,7 +1,7 @@
@@ -643,12 +765,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with very long lines`() {
+        // given
         val longLine = "a".repeat(2000)
         val modifiedLongLine = "a".repeat(1999) + "b"
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             modifiedLongLine sameAs longLine
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -667,9 +794,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with only blank lines`() {
-        assertFailsWith<AssertionError> {
-            "\n\n" sameAs "\n\n\n"
-        }.message sameAs """
+        // given
+        val expected = "\n\n\n"
+        val actual = "\n\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,3 +1,2 @@
@@ -682,6 +817,7 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with lines that look like diff markers`() {
+        // given
         val expected = """
             --- normal line
             +++ another line
@@ -702,9 +838,13 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,4 +1,4 @@
@@ -719,8 +859,8 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with adjacent hunks within context distance`() {
-        // Two changes that are 3 lines apart (within default context of 3)
-        // should result in a single merged hunk
+        // given
+        // two changes that are 3 lines apart (within default context of 3)
         val expected = """
             line1
             change1
@@ -743,9 +883,14 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        // should result in a single merged hunk
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,7 +1,7 @@
@@ -764,8 +909,8 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with adjacent hunks beyond context distance`() {
-        // Two changes that are more than 6 lines apart (beyond 2x context of 3)
-        // should result in separate hunks
+        // given
+        // two changes that are more than 6 lines apart (beyond 2x context of 3)
         val expected = """
             line1
             change1
@@ -798,9 +943,14 @@ class SameAsTest {
 
         """.trimIndent()
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        // should result in separate hunks
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,5 +1,5 @@
@@ -830,9 +980,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with control characters`() {
-        assertFailsWith<AssertionError> {
-            "line1\u0007\nline2\u001b" sameAs "line1\nline2"
-        }.message sameAs """
+        // given
+        val expected = "line1\nline2"
+        val actual = "line1\u0007\nline2\u001b"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,2 +1,2 @@
@@ -848,13 +1006,18 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with single character change in long identical strings`() {
+        // given
         val baseString = "a".repeat(100)
         val actual = baseString + "x"
         val expected = baseString + "y"
 
-        assertFailsWith<AssertionError> {
+        // when
+        val error = assertFailsWith<AssertionError> {
             actual sameAs expected
-        }.message sameAs """
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -868,9 +1031,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with tab character at various positions`() {
-        assertFailsWith<AssertionError> {
-            "\tstart\nmiddle\there\nend\t\n" sameAs "start\nmiddle here\nend\n"
-        }.message sameAs """
+        // given
+        val expected = "start\nmiddle here\nend\n"
+        val actual = "\tstart\nmiddle\there\nend\t\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,3 +1,3 @@
@@ -886,9 +1057,17 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with backslash characters`() {
-        assertFailsWith<AssertionError> {
-            "path\\to\\file\n" sameAs "path/to/file\n"
-        }.message sameAs """
+        // given
+        val expected = "path/to/file\n"
+        val actual = "path\\to\\file\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+             actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1 +1 @@
@@ -900,15 +1079,959 @@ class SameAsTest {
 
     @Test
     fun `should fail and report difference with quoted strings in content`() {
-        assertFailsWith<AssertionError> {
-            "\"quoted string\"\n'single quotes'\n" sameAs "\"different string\"\n'single quotes'\n"
-        }.message sameAs """
+        // given
+        val expected = "\"different string\"\n'single quotes'\n"
+        val actual = "\"quoted string\"\n'single quotes'\n"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        error.message sameAs """
             --- expected
             +++ actual
             @@ -1,2 +1,2 @@
             -"different string"
             +"quoted string"
              'single quotes'
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should not truncate diff when exactly at 100 changed lines threshold`() {
+        // given
+        val expected = (1..50).joinToString("\n") { "old$it" }
+        val actual = (1..50).joinToString("\n") { "new$it" }
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        // exactly 100 changed lines (50 deletes + 50 inserts)
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,50 +1,50 @@
+            -old1
+            -old2
+            -old3
+            -old4
+            -old5
+            -old6
+            -old7
+            -old8
+            -old9
+            -old10
+            -old11
+            -old12
+            -old13
+            -old14
+            -old15
+            -old16
+            -old17
+            -old18
+            -old19
+            -old20
+            -old21
+            -old22
+            -old23
+            -old24
+            -old25
+            -old26
+            -old27
+            -old28
+            -old29
+            -old30
+            -old31
+            -old32
+            -old33
+            -old34
+            -old35
+            -old36
+            -old37
+            -old38
+            -old39
+            -old40
+            -old41
+            -old42
+            -old43
+            -old44
+            -old45
+            -old46
+            -old47
+            -old48
+            -old49
+            -old50
+            \ No newline at end of file
+            +new1
+            +new2
+            +new3
+            +new4
+            +new5
+            +new6
+            +new7
+            +new8
+            +new9
+            +new10
+            +new11
+            +new12
+            +new13
+            +new14
+            +new15
+            +new16
+            +new17
+            +new18
+            +new19
+            +new20
+            +new21
+            +new22
+            +new23
+            +new24
+            +new25
+            +new26
+            +new27
+            +new28
+            +new29
+            +new30
+            +new31
+            +new32
+            +new33
+            +new34
+            +new35
+            +new36
+            +new37
+            +new38
+            +new39
+            +new40
+            +new41
+            +new42
+            +new43
+            +new44
+            +new45
+            +new46
+            +new47
+            +new48
+            +new49
+            +new50
+            \ No newline at end of file
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should truncate diff when changes exceed reasonable size for LLM consumption`() {
+        // given
+        // a large string with many different lines that would generate a huge diff
+        // expected has 250 lines, actual has 300 lines - both exceeding the 100-line change threshold
+        val largeExpected = (1000..1249).joinToString("\n") { "$it" }
+        val largeActual = (2000..2299).joinToString("\n") { "$it" }
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            largeActual sameAs largeExpected
+        }
+
+        // then
+        // we expect the diff to show only the first 100 changed lines
+        // since all lines are different, the diff will show deletions followed by insertions
+        // we truncate after 100 changed lines (counting both + and - lines)
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,100 +0,0 @@
+            -1000
+            -1001
+            -1002
+            -1003
+            -1004
+            -1005
+            -1006
+            -1007
+            -1008
+            -1009
+            -1010
+            -1011
+            -1012
+            -1013
+            -1014
+            -1015
+            -1016
+            -1017
+            -1018
+            -1019
+            -1020
+            -1021
+            -1022
+            -1023
+            -1024
+            -1025
+            -1026
+            -1027
+            -1028
+            -1029
+            -1030
+            -1031
+            -1032
+            -1033
+            -1034
+            -1035
+            -1036
+            -1037
+            -1038
+            -1039
+            -1040
+            -1041
+            -1042
+            -1043
+            -1044
+            -1045
+            -1046
+            -1047
+            -1048
+            -1049
+            -1050
+            -1051
+            -1052
+            -1053
+            -1054
+            -1055
+            -1056
+            -1057
+            -1058
+            -1059
+            -1060
+            -1061
+            -1062
+            -1063
+            -1064
+            -1065
+            -1066
+            -1067
+            -1068
+            -1069
+            -1070
+            -1071
+            -1072
+            -1073
+            -1074
+            -1075
+            -1076
+            -1077
+            -1078
+            -1079
+            -1080
+            -1081
+            -1082
+            -1083
+            -1084
+            -1085
+            -1086
+            -1087
+            -1088
+            -1089
+            -1090
+            -1091
+            -1092
+            -1093
+            -1094
+            -1095
+            -1096
+            -1097
+            -1098
+            -1099
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: 250 lines
+            Actual: 300 lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should truncate diff in middle of single large hunk`() {
+        // given
+        // a single large hunk with more than 100 changes
+        val expected = (1..150).joinToString("\n") { "line$it" }
+        val actual = (1..150).joinToString("\n") { "modified$it" }
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        // all lines are different: 150 deletions + 150 insertions = 300 total changes
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,100 +0,0 @@
+            -line1
+            -line2
+            -line3
+            -line4
+            -line5
+            -line6
+            -line7
+            -line8
+            -line9
+            -line10
+            -line11
+            -line12
+            -line13
+            -line14
+            -line15
+            -line16
+            -line17
+            -line18
+            -line19
+            -line20
+            -line21
+            -line22
+            -line23
+            -line24
+            -line25
+            -line26
+            -line27
+            -line28
+            -line29
+            -line30
+            -line31
+            -line32
+            -line33
+            -line34
+            -line35
+            -line36
+            -line37
+            -line38
+            -line39
+            -line40
+            -line41
+            -line42
+            -line43
+            -line44
+            -line45
+            -line46
+            -line47
+            -line48
+            -line49
+            -line50
+            -line51
+            -line52
+            -line53
+            -line54
+            -line55
+            -line56
+            -line57
+            -line58
+            -line59
+            -line60
+            -line61
+            -line62
+            -line63
+            -line64
+            -line65
+            -line66
+            -line67
+            -line68
+            -line69
+            -line70
+            -line71
+            -line72
+            -line73
+            -line74
+            -line75
+            -line76
+            -line77
+            -line78
+            -line79
+            -line80
+            -line81
+            -line82
+            -line83
+            -line84
+            -line85
+            -line86
+            -line87
+            -line88
+            -line89
+            -line90
+            -line91
+            -line92
+            -line93
+            -line94
+            -line95
+            -line96
+            -line97
+            -line98
+            -line99
+            -line100
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: 150 lines
+            Actual: 150 lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should truncate diff across multiple hunks`() {
+        // given
+        // multiple separate changes that form different hunks
+        // Each range creates lines, so we need to count: 30 + 40 + 30 + 40 = 140 lines
+        // Plus 3 newlines between sections = 143 lines total
+        val expected = buildString {
+            append((1..30).joinToString("\n") { "unchanged$it" })
+            append("\n")
+            append((1..40).joinToString("\n") { "change1-$it" })
+            append("\n")
+            append((1..30).joinToString("\n") { "unchanged$it" })
+            append("\n")
+            append((1..40).joinToString("\n") { "change2-$it" })
+        }
+
+        val actual = buildString {
+            append((1..30).joinToString("\n") { "unchanged$it" })
+            append("\n")
+            append((1..40).joinToString("\n") { "modified1-$it" })
+            append("\n")
+            append((1..30).joinToString("\n") { "unchanged$it" })
+            append("\n")
+            append((1..40).joinToString("\n") { "modified2-$it" })
+        }
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        val lineCount = expected.count { it == '\n' } + 1
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -28,46 +28,46 @@
+             unchanged28
+             unchanged29
+             unchanged30
+            -change1-1
+            -change1-2
+            -change1-3
+            -change1-4
+            -change1-5
+            -change1-6
+            -change1-7
+            -change1-8
+            -change1-9
+            -change1-10
+            -change1-11
+            -change1-12
+            -change1-13
+            -change1-14
+            -change1-15
+            -change1-16
+            -change1-17
+            -change1-18
+            -change1-19
+            -change1-20
+            -change1-21
+            -change1-22
+            -change1-23
+            -change1-24
+            -change1-25
+            -change1-26
+            -change1-27
+            -change1-28
+            -change1-29
+            -change1-30
+            -change1-31
+            -change1-32
+            -change1-33
+            -change1-34
+            -change1-35
+            -change1-36
+            -change1-37
+            -change1-38
+            -change1-39
+            -change1-40
+            +modified1-1
+            +modified1-2
+            +modified1-3
+            +modified1-4
+            +modified1-5
+            +modified1-6
+            +modified1-7
+            +modified1-8
+            +modified1-9
+            +modified1-10
+            +modified1-11
+            +modified1-12
+            +modified1-13
+            +modified1-14
+            +modified1-15
+            +modified1-16
+            +modified1-17
+            +modified1-18
+            +modified1-19
+            +modified1-20
+            +modified1-21
+            +modified1-22
+            +modified1-23
+            +modified1-24
+            +modified1-25
+            +modified1-26
+            +modified1-27
+            +modified1-28
+            +modified1-29
+            +modified1-30
+            +modified1-31
+            +modified1-32
+            +modified1-33
+            +modified1-34
+            +modified1-35
+            +modified1-36
+            +modified1-37
+            +modified1-38
+            +modified1-39
+            +modified1-40
+             unchanged1
+             unchanged2
+             unchanged3
+            @@ -98,23 +98,3 @@
+             unchanged28
+             unchanged29
+             unchanged30
+            -change2-1
+            -change2-2
+            -change2-3
+            -change2-4
+            -change2-5
+            -change2-6
+            -change2-7
+            -change2-8
+            -change2-9
+            -change2-10
+            -change2-11
+            -change2-12
+            -change2-13
+            -change2-14
+            -change2-15
+            -change2-16
+            -change2-17
+            -change2-18
+            -change2-19
+            -change2-20
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: $lineCount lines
+            Actual: $lineCount lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should handle truncation with newline markers correctly`() {
+        // given
+        // Large diff where last line has no newline
+        val expected = (1..120).joinToString("\n") { "line$it" }
+        val actual = (1..120).joinToString("\n") { "other$it" } + "extra"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        // Should truncate after 100 changed lines
+        // The diff will show deletions of line1-line100, then truncate
+        // "extra" should not appear since we stop at 100 changes
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,100 +0,0 @@
+            -line1
+            -line2
+            -line3
+            -line4
+            -line5
+            -line6
+            -line7
+            -line8
+            -line9
+            -line10
+            -line11
+            -line12
+            -line13
+            -line14
+            -line15
+            -line16
+            -line17
+            -line18
+            -line19
+            -line20
+            -line21
+            -line22
+            -line23
+            -line24
+            -line25
+            -line26
+            -line27
+            -line28
+            -line29
+            -line30
+            -line31
+            -line32
+            -line33
+            -line34
+            -line35
+            -line36
+            -line37
+            -line38
+            -line39
+            -line40
+            -line41
+            -line42
+            -line43
+            -line44
+            -line45
+            -line46
+            -line47
+            -line48
+            -line49
+            -line50
+            -line51
+            -line52
+            -line53
+            -line54
+            -line55
+            -line56
+            -line57
+            -line58
+            -line59
+            -line60
+            -line61
+            -line62
+            -line63
+            -line64
+            -line65
+            -line66
+            -line67
+            -line68
+            -line69
+            -line70
+            -line71
+            -line72
+            -line73
+            -line74
+            -line75
+            -line76
+            -line77
+            -line78
+            -line79
+            -line80
+            -line81
+            -line82
+            -line83
+            -line84
+            -line85
+            -line86
+            -line87
+            -line88
+            -line89
+            -line90
+            -line91
+            -line92
+            -line93
+            -line94
+            -line95
+            -line96
+            -line97
+            -line98
+            -line99
+            -line100
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: 120 lines
+            Actual: 120 lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should truncate when first 100 changes are all deletions`() {
+        // given
+        val expected = (1..200).joinToString("\n") { "line$it" }
+        val actual = "single line"
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        // Should show first 100 deletions only, then truncate
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,100 +0,0 @@
+            -line1
+            -line2
+            -line3
+            -line4
+            -line5
+            -line6
+            -line7
+            -line8
+            -line9
+            -line10
+            -line11
+            -line12
+            -line13
+            -line14
+            -line15
+            -line16
+            -line17
+            -line18
+            -line19
+            -line20
+            -line21
+            -line22
+            -line23
+            -line24
+            -line25
+            -line26
+            -line27
+            -line28
+            -line29
+            -line30
+            -line31
+            -line32
+            -line33
+            -line34
+            -line35
+            -line36
+            -line37
+            -line38
+            -line39
+            -line40
+            -line41
+            -line42
+            -line43
+            -line44
+            -line45
+            -line46
+            -line47
+            -line48
+            -line49
+            -line50
+            -line51
+            -line52
+            -line53
+            -line54
+            -line55
+            -line56
+            -line57
+            -line58
+            -line59
+            -line60
+            -line61
+            -line62
+            -line63
+            -line64
+            -line65
+            -line66
+            -line67
+            -line68
+            -line69
+            -line70
+            -line71
+            -line72
+            -line73
+            -line74
+            -line75
+            -line76
+            -line77
+            -line78
+            -line79
+            -line80
+            -line81
+            -line82
+            -line83
+            -line84
+            -line85
+            -line86
+            -line87
+            -line88
+            -line89
+            -line90
+            -line91
+            -line92
+            -line93
+            -line94
+            -line95
+            -line96
+            -line97
+            -line98
+            -line99
+            -line100
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: 200 lines
+            Actual: 1 lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
+
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should truncate when first 100 changes are all insertions`() {
+        // given
+        val expected = "single line"
+        val actual = (1..200).joinToString("\n") { "line$it" }
+
+        // when
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+
+        // then
+        // Should show deletion then first 99 insertions (100 changes total), then truncate
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1 +1,99 @@
+            -single line
+            \ No newline at end of file
+            +line1
+            +line2
+            +line3
+            +line4
+            +line5
+            +line6
+            +line7
+            +line8
+            +line9
+            +line10
+            +line11
+            +line12
+            +line13
+            +line14
+            +line15
+            +line16
+            +line17
+            +line18
+            +line19
+            +line20
+            +line21
+            +line22
+            +line23
+            +line24
+            +line25
+            +line26
+            +line27
+            +line28
+            +line29
+            +line30
+            +line31
+            +line32
+            +line33
+            +line34
+            +line35
+            +line36
+            +line37
+            +line38
+            +line39
+            +line40
+            +line41
+            +line42
+            +line43
+            +line44
+            +line45
+            +line46
+            +line47
+            +line48
+            +line49
+            +line50
+            +line51
+            +line52
+            +line53
+            +line54
+            +line55
+            +line56
+            +line57
+            +line58
+            +line59
+            +line60
+            +line61
+            +line62
+            +line63
+            +line64
+            +line65
+            +line66
+            +line67
+            +line68
+            +line69
+            +line70
+            +line71
+            +line72
+            +line73
+            +line74
+            +line75
+            +line76
+            +line77
+            +line78
+            +line79
+            +line80
+            +line81
+            +line82
+            +line83
+            +line84
+            +line85
+            +line86
+            +line87
+            +line88
+            +line89
+            +line90
+            +line91
+            +line92
+            +line93
+            +line94
+            +line95
+            +line96
+            +line97
+            +line98
+            +line99
+
+            Diff truncated: more than 100 lines changed
+
+            Expected: 1 lines
+            Actual: 200 lines
+
+            The differences are too extensive to show in unified diff format.
+            Consider comparing smaller sections or reviewing the strings directly.
 
         """.trimIndent()
     }


### PR DESCRIPTION
Prevents overwhelming LLMs with diffs containing hundreds of changes. When more than 100 changed lines are detected, the diff is truncated to show only the first 100 changes followed by a summary message.

- Add truncateIfNeeded() to limit diff output size
- Add recalculateHunkHeader() to adjust hunk ranges after truncation
- Add comprehensive tests for truncation behavior
- Refactor existing tests to follow given-when-then pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)