### PR TITLE
Update Dokka plugin to 2.1.0 and add dependency stability filters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalWasmDsl::class, ExperimentalKotlinGradlePluginApi::class)
 
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.xemantic.gradle.conventions.License
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -277,5 +279,21 @@ jreleaser {
             active = Active.ALWAYS
             status = releaseAnnouncement
         }
+    }
+}
+
+val unstableKeywords = listOf("alpha", "beta", "rc")
+
+fun isNonStable(
+    version: String
+) = version.lowercase().let { normalizedVersion ->
+    unstableKeywords.any {
+        it in normalizedVersion
+    }
+}
+
+tasks.withType<DependencyUpdatesTask> {
+    rejectVersionIf {
+        isNonStable(candidate.version)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin = "2.2.20"
 kotlinxCoroutines = "1.10.2"
 
 versionsPlugin = "0.53.0"
-dokkaPlugin = "2.0.0"
+dokkaPlugin = "2.1.0"
 jreleaserPlugin = "1.20.0"
 binaryCompatibilityValidatorPlugin = "0.18.1"
 xemanticConventionsPlugin = "0.4.3"


### PR DESCRIPTION
- Upgrade dokka-plugin from 2.0.0 to 2.1.0
- Configure dependency updates task to reject unstable versions (alpha, beta, rc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)