### PR TITLE
Add JSON syntax highlighting support to sameAsJson function

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlin.test)
                 implementation(libs.kotlinx.serialization.json)
+                api(libs.jetbrains.annotations)
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ xemanticConventionsPlugin = "0.4.3"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.2-1" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/src/commonMain/kotlin/SameAsJson.kt
+++ b/src/commonMain/kotlin/SameAsJson.kt
@@ -19,6 +19,7 @@ package com.xemantic.kotlin.test
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import org.intellij.lang.annotations.Language
 import kotlin.test.fail
 
 /**
@@ -40,7 +41,9 @@ import kotlin.test.fail
  * @throws AssertionError if the strings are not equal, with unified diff output.
  * @throws IllegalArgumentException if the expected JSON is malformed.
  */
-public infix fun String?.sameAsJson(expected: String) {
+public infix fun String?.sameAsJson(
+    @Language("json") expected: String
+) {
 
     if (this == null) {
         fail("The string is null, but expected to be: $expected")


### PR DESCRIPTION
## Summary

- Added `@Language("json")` annotation to the `expected` parameter of `sameAsJson` function
- Added jetbrains-annotations dependency to enable IDE syntax highlighting for JSON strings
- Improves developer experience by providing JSON syntax highlighting and validation in test assertions

## Changes

- **build.gradle.kts**: Added jetbrains-annotations dependency to commonMain
- **gradle/libs.versions.toml**: Added jetbrains-annotations library reference (version 26.0.2-1)
- **SameAsJson.kt**: Applied `@Language("json")` annotation to expected parameter and imported required annotation class

## Test plan

- [ ] Verify that existing tests pass with `./gradlew allTests`
- [ ] Verify JSON syntax highlighting works in IntelliJ IDEA when using sameAsJson
- [ ] Verify API compatibility with `./gradlew apiCheck`
- [ ] Check that the annotation doesn't break multiplatform compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)