### PR TITLE
Add chunkedRandomly string extension for testing streaming text

### DIFF
--- a/api/xemantic-kotlin-test.api
+++ b/api/xemantic-kotlin-test.api
@@ -27,3 +27,8 @@ public final class com/xemantic/kotlin/test/coroutines/SuspendShouldKt {
 	public static final fun should (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/xemantic/kotlin/test/text/StringChunkingKt {
+	public static final fun chunkedRandomly (Ljava/lang/CharSequence;II)Lkotlin/sequences/Sequence;
+	public static synthetic fun chunkedRandomly$default (Ljava/lang/CharSequence;IIILjava/lang/Object;)Lkotlin/sequences/Sequence;
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ kotlin.incremental.wasm=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 version=0.1-SNAPSHOT
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlinTarget = "2.2"
+kotlinTarget = "2.3"
 javaTarget = "1.8"
 
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.9.0"
 
@@ -10,13 +10,15 @@ versionsPlugin = "0.53.0"
 dokkaPlugin = "2.1.0"
 jreleaserPlugin = "1.20.0"
 binaryCompatibilityValidatorPlugin = "0.18.1"
-xemanticConventionsPlugin = "0.4.3"
+xemanticConventionsPlugin = "0.6.8"
+jetbrainsAnnotations = "26.0.2-1"
+mavenPublishPlugin = "0.35.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.2-1" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -24,5 +26,6 @@ kotlin-plugin-power-assert = { id = "org.jetbrains.kotlin.plugin.power-assert", 
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidatorPlugin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaserPlugin" }
 xemantic-conventions = { id = "com.xemantic.gradle.xemantic-conventions", version.ref = "xemanticConventionsPlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -722,10 +722,10 @@ engine.io@~6.6.0:
     engine.io-parser "~5.2.1"
     ws "~8.17.1"
 
-enhanced-resolve@^5.17.2:
-  version "5.18.3"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz#9b5f4c5c076b8787c78fe540392ce76a88855b44"
-  integrity sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==
+enhanced-resolve@^5.17.3:
+  version "5.18.4"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz#c22d33055f3952035ce6a144ce092447c525f828"
+  integrity sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -1209,10 +1209,9 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.4:
+"karma@github:Kotlin/karma#6.4.5":
   version "6.4.4"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
-  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
+  resolved "https://codeload.github.com/Kotlin/karma/tar.gz/239a8fc984584f0d96b1dd750e7a5e2c79da93a6"
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1244,10 +1243,10 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kotlin-web-helpers@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.1.0.tgz#6cd4b0f0dc3baea163929c8638155b8d19c55a74"
-  integrity sha512-NAJhiNB84tnvJ5EQx7iER3GWw7rsTZkX9HVHZpe7E3dDBD/dhTzqgSwNU3MfQjniy2rB04bP24WM9Z32ntUWRg==
+kotlin-web-helpers@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-3.0.0.tgz#3ed6b48f694f74bb60a737a9d7e2c0e3b29abdb9"
+  integrity sha512-kdQO4AJQkUPvpLh9aglkXDRyN+CfXO7pKq+GESEnxooBFkQpytLrqZis3ABvmFN1cGw/ZQ/K38u5sRGW+NfBnw==
   dependencies:
     format-util "^1.0.5"
 
@@ -1357,10 +1356,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@11.7.1:
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.1.tgz#91948fecd624fb4bd154ed260b7e1ad3910d7c7a"
-  integrity sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==
+mocha@11.7.2:
+  version "11.7.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.2.tgz#3c0079fe5cc2f8ea86d99124debcc42bb1ab22b5"
+  integrity sha512-lkqVJPmqqG/w5jmmFtiRvtA2jkDyNVUcefFJKb2uyX4dekk8Okgqop3cgbFiaIvj8uCRJVTP5x9dfxGyXm2jvQ==
   dependencies:
     browser-stdout "^1.3.1"
     chokidar "^4.0.1"
@@ -1988,10 +1987,10 @@ webpack-sources@^3.3.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.3.3.tgz#d4bf7f9909675d7a070ff14d0ef2a4f3c982c723"
   integrity sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==
 
-webpack@5.100.2:
-  version "5.100.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.100.2.tgz#e2341facf9f7de1d702147c91bcb65b693adf9e8"
-  integrity sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==
+webpack@5.101.3:
+  version "5.101.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.101.3.tgz#3633b2375bb29ea4b06ffb1902734d977bc44346"
+  integrity sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==
   dependencies:
     "@types/eslint-scope" "^3.7.7"
     "@types/estree" "^1.0.8"
@@ -2003,7 +2002,7 @@ webpack@5.100.2:
     acorn-import-phases "^1.0.3"
     browserslist "^4.24.0"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.17.2"
+    enhanced-resolve "^5.17.3"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"

--- a/src/commonMain/kotlin/text/StringChunking.kt
+++ b/src/commonMain/kotlin/text/StringChunking.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.kotlin.test.text
+
+/**
+ * Splits this string into a [Sequence] of chunks with random lengths.
+ *
+ * Useful for testing streaming text processing, simulating chunked API responses,
+ * or validating that code correctly handles arbitrarily split input.
+ */
+public fun CharSequence.chunkedRandomly(
+    minLength: Int = 0,
+    maxLength: Int = 10
+): Sequence<String> {
+
+    require(minLength <= maxLength) {
+        "minLength ($minLength) must be <= maxLength ($maxLength)"
+    }
+
+    return sequence {
+        val sizeRange = minLength..maxLength
+        var index = 0
+        while (index < length) {
+            val chunkSize = maxOf(1, sizeRange.random())
+            val end = minOf(index + chunkSize, length)
+            yield(substring(index, end))
+            index = end
+        }
+    }
+}

--- a/src/commonTest/kotlin/text/ChunkedRandomlyTest.kt
+++ b/src/commonTest/kotlin/text/ChunkedRandomlyTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.kotlin.test.text
+
+import com.xemantic.kotlin.test.assert
+import com.xemantic.kotlin.test.have
+import com.xemantic.kotlin.test.sameAs
+import com.xemantic.kotlin.test.should
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class ChunkedRandomlyTest {
+
+    @Test
+    fun `should chunk string randomly and reconstruct original`() {
+        // given
+        val text = """
+            The quick brown fox jumps over the lazy dog. This pangram contains every letter
+            of the English alphabet at least once. It has been used since the late 19th
+            century to test typewriters and computer keyboards, as well as to display font
+            samples. The phrase is notable for its brevity while still containing all 26
+            letters, making it an ideal test case for text processing algorithms.
+
+            In addition to its practical applications, the sentence has become a cultural
+            reference, appearing in various forms of media and literature. Software developers
+            often use it when testing text rendering, chunking algorithms, and streaming
+            implementations. The fox, in this context, represents the flow of data being
+            processed in discrete segments, while the lazy dog symbolizes the patient
+            accumulation of those segments into a coherent whole.
+        """.trimIndent()
+
+        // when
+        val chunks = text.chunkedRandomly().toList()
+
+        // then
+        assert(chunks.size > 1)
+        chunks.joinToString("") sameAs text
+    }
+
+    @Test
+    fun `should return empty sequence for empty string`() {
+        // when
+        val chunks = "".chunkedRandomly().toList()
+
+        // then
+        assert(chunks.isEmpty())
+    }
+
+    @Test
+    fun `should handle single character string`() {
+        // when
+        val chunks = "X".chunkedRandomly().toList()
+
+        // then
+        chunks should {
+            have(size == 1)
+            have(first() == "X")
+        }
+    }
+
+    @Test
+    fun `should produce fixed size chunks when minLength equals maxLength`() {
+        // given
+        val text = "abcdefghij" // 10 characters
+
+        // when
+        val chunks = text.chunkedRandomly(minLength = 2, maxLength = 2).toList()
+
+        // then
+        chunks should {
+            have(size == 5)
+            have(all { it.length == 2 })
+        }
+        chunks.joinToString("") sameAs text
+    }
+
+    @Test
+    fun `should respect chunk size bounds`() {
+        // given
+        val text = "The quick brown fox jumps over the lazy dog"
+        val minLength = 3
+        val maxLength = 7
+
+        // when
+        val chunks = text.chunkedRandomly(minLength = minLength, maxLength = maxLength).toList()
+
+        // then
+        val allButLast = chunks.dropLast(1)
+        allButLast should {
+            have(all { it.length in minLength..maxLength })
+        }
+        // last chunk may be smaller if remaining text is shorter than minLength
+        chunks.last() should {
+            have(length in 1..maxLength)
+        }
+        chunks.joinToString("") sameAs text
+    }
+
+    @Test
+    fun `should handle string shorter than minLength`() {
+        // given
+        val text = "hi" // 2 characters
+
+        // when
+        val chunks = text.chunkedRandomly(minLength = 5, maxLength = 10).toList()
+
+        // then
+        chunks should {
+            have(size == 1)
+            have(first() == "hi")
+        }
+    }
+
+    @Test
+    fun `should throw when minLength is greater than maxLength`() {
+        // when
+        val error = assertFailsWith<IllegalArgumentException> {
+            "test".chunkedRandomly(minLength = 10, maxLength = 5)
+        }
+
+        // then
+        assert(error.message == "minLength (10) must be <= maxLength (5)")
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add new `chunkedRandomly()` extension function that splits strings into random-length chunks, useful for testing streaming text processing and chunked API responses
- Upgrade Kotlin to 2.3.0 and Gradle wrapper to 9.2.1
- Switch to vanniktech maven-publish plugin for simplified publishing configuration
- Update xemantic-conventions plugin to 0.6.8
- Improve CLAUDE.md documentation with assertion function reference table

## Test plan
- [x] New `ChunkedRandomlyTest` covers various edge cases (empty strings, single characters, fixed-size chunks, bounds validation)
- [ ] Run `./gradlew allTests` to verify all platforms
- [ ] Run `./gradlew apiCheck` to verify API compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)