### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -63,7 +63,7 @@ jobs:
         run: ./gradlew -Pversion=$VERSION updateVersionsAfterRelease
 
       - name: Commit version updates after release
-        uses: stefanzweifel/git-auto-commit-action@v7.0.0
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         with:
           commit_message: Version updated to ${{ env.VERSION }} in README.md, next snapshot in gradle.properties
           file_pattern: 'README.md gradle.properties'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v7.1.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7.1.0)** on 2025-12-17T19:25:45Z
