### PR TITLE
Update dependencies and force ASM to latest version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,6 +157,14 @@ repositories {
     mavenCentral()
 }
 
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.ow2.asm") {
+            useVersion(libs.versions.asm.get())
+        }
+    }
+}
+
 tasks {
 
     // skip tests which require XCode components to be installed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,12 @@ kotlinxSerialization = "1.9.0"
 
 versionsPlugin = "0.53.0"
 dokkaPlugin = "2.1.0"
-jreleaserPlugin = "1.20.0"
+jreleaserPlugin = "1.22.0"
 binaryCompatibilityValidatorPlugin = "0.18.1"
 xemanticConventionsPlugin = "0.6.8"
 jetbrainsAnnotations = "26.0.2-1"
 mavenPublishPlugin = "0.35.0"
+asm = "9.9.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Update jreleaser plugin from 1.20.0 to 1.22.0
- Add resolution strategy to force `org.ow2.asm` dependencies to latest version (9.9.1), preventing stale transitive dependency reports in `dependencyUpdates` task

## Test plan
- [x] Run `./gradlew dependencyUpdates` and verify ASM libraries show as "using the latest milestone version"

🤖 Generated with [Claude Code](https://claude.ai/code)