### PR TITLE
Use PR for post-release version updates instead of direct push

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,16 +8,17 @@ on:
 jobs:
   build_release:
     runs-on: ubuntu-latest
-    permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      target_branch: ${{ steps.target_branch.outputs.target_branch }}
     steps:
       - name: Write release version
+        id: version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout sources
         uses: actions/checkout@v6.0.1
@@ -43,27 +44,57 @@ jobs:
           JRELEASER_BLUESKY_HOST: ${{ vars.BLUESKY_HOST }}
           JRELEASER_BLUESKY_HANDLE: ${{ vars.BLUESKY_HANDLE }}
           JRELEASER_BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
-
         run: ./gradlew -Pversion=$VERSION build publishToMavenCentral jreleaserAnnounce --no-configuration-cache
 
       - name: Get target branch for tag
+        id: target_branch
         run: |
           git fetch --all
           TARGET_BRANCH=$(git branch -r --contains $GITHUB_REF | grep -v "HEAD" | head -n 1 | sed 's/origin\///')
           echo "Target branch for tag: $TARGET_BRANCH"
-          echo "TARGET_BRANCH=$TARGET_BRANCH" >> $GITHUB_ENV
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
 
+  update_versions:
+    needs: build_release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
       - name: Checkout target branch
         uses: actions/checkout@v6.0.1
         with:
-          ref: ${{ env.TARGET_BRANCH }}
-          fetch-depth: 0
+          ref: ${{ needs.build_release.outputs.target_branch }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v5.1.0
+        with:
+          distribution: ${{ vars.DEFAULT_JAVA_DISTRIBUTION }}
+          java-version: ${{ vars.DEFAULT_JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
 
       - name: Update versions after release
-        run: ./gradlew -Pversion=$VERSION updateVersionsAfterRelease
+        run: ./gradlew -Pversion=${{ needs.build_release.outputs.version }} updateVersionsAfterRelease
 
-      - name: Commit version updates after release
-        uses: stefanzweifel/git-auto-commit-action@v7.1.0
-        with:
-          commit_message: Version updated to ${{ env.VERSION }} in README.md, next snapshot in gradle.properties
-          file_pattern: 'README.md gradle.properties'
+      - name: Create PR for version updates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.build_release.outputs.version }}
+          TARGET_BRANCH: ${{ needs.build_release.outputs.target_branch }}
+        run: |
+          BRANCH_NAME="post-release-v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH_NAME"
+          git add README.md gradle.properties
+          git commit -m "Version updated to $VERSION in README.md, next snapshot in gradle.properties"
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --title "Post-release version update for v$VERSION" \
+            --body "Automated version update after release v$VERSION.
+
+          - Updates version in README.md
+          - Sets next snapshot version in gradle.properties" \
+            --base "$TARGET_BRANCH"


### PR DESCRIPTION
## Summary
- Split release workflow into two separate jobs for better separation of concerns
- `build_release` job now outputs version and target branch for the next job
- New `update_versions` job creates a PR for version updates instead of pushing directly to main
- Respects branch protection rules that prevent direct pushes

## Context
The previous workflow used `stefanzweifel/git-auto-commit-action` to push version updates directly to main after a release. With branch protection rules now in place, this approach fails. This PR changes the workflow to create a PR for the version updates instead.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with next release to confirm PR is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)