### PR TITLE
fix: normalize CRLF line endings in sameAs diff output

### DIFF
--- a/src/commonMain/kotlin/SameAs.kt
+++ b/src/commonMain/kotlin/SameAs.kt
@@ -71,16 +71,22 @@ public infix fun String?.sameAsXml(
  *
  * The standard [String.lines] function adds a trailing empty string when the string ends with \n.
  * This helper removes that trailing empty string to get the actual line content.
+ *
+ * Trailing `\r` characters are stripped from each line to normalize CRLF (`\r\n`) line endings
+ * to LF, so that diff output is readable in terminals and CRLF/LF differences do not garble
+ * the `-`/`+` prefixes via carriage-return overwrite.
  */
 private fun String.splitLinesForDiff(): List<String> {
     if (isEmpty()) return emptyList()
     val lines = lines()
     // If string ends with newline, lines() adds ONE trailing empty string - remove only that one
-    return if (lines.size > 1 && endsWith('\n') && lines.last().isEmpty()) {
+    val trimmedLines = if (lines.size > 1 && endsWith('\n') && lines.last().isEmpty()) {
         lines.dropLast(1)
     } else {
         lines
     }
+    // Normalize CRLF line endings: strip trailing \r so diff output is not garbled in terminals
+    return trimmedLines.map { it.trimEnd('\r') }
 }
 
 /**

--- a/src/commonTest/kotlin/SameAsTest.kt
+++ b/src/commonTest/kotlin/SameAsTest.kt
@@ -36,7 +36,7 @@ class SameAsTest {
     fun `should pass on equal HTML strings using sameAsHtml`() {
         // given
         val html = """
-            <html lang='en'>
+            <html lang="en">
             <body>
               <h1>Hello World</h1>
               <p>This is a <strong>test</strong> paragraph.</p>
@@ -57,7 +57,7 @@ class SameAsTest {
     fun `should fail and report difference on different HTML strings using sameAsHtml`() {
         // given
         val actual = /* language=html */ """
-            <html lang='en'>
+            <html lang="en">
             <body>
               <h1>Hello World</h1>
               <p>Updated paragraph.</p>
@@ -71,7 +71,7 @@ class SameAsTest {
         """.trimIndent()
 
         val expected = """
-            <html lang='en'>
+            <html lang="en">
             <body>
               <h1>Hello World</h1>
               <p>Original paragraph.</p>
@@ -94,7 +94,7 @@ class SameAsTest {
             --- expected
             +++ actual
             @@ -1,10 +1,10 @@
-             <html>
+             <html lang="en">
              <body>
                <h1>Hello World</h1>
             -  <p>Original paragraph.</p>

--- a/src/commonTest/kotlin/SameAsTest.kt
+++ b/src/commonTest/kotlin/SameAsTest.kt
@@ -18,6 +18,8 @@ package com.xemantic.kotlin.test
 
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * The [sameAs] reports differences in unified diff format.
@@ -2327,6 +2329,57 @@ class SameAsTest {
             Consider comparing smaller sections or reviewing the strings directly.
 
         """.trimIndent()
+    }
+
+    @Test
+    fun `should pass on identical strings with CRLF line endings`() {
+        val string = "unchanged line\r\nexpected content\r\n"
+        string sameAs string
+    }
+
+    @Test
+    fun `should produce readable diff without raw CR for CRLF strings differing in content`() {
+        val expected = "unchanged line\r\nexpected content\r\n"
+        val actual   = "unchanged line\r\nactual content\r\n"
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+        val message = error.message!!
+        assertFalse('\r' in message, "Diff output must not contain raw \\r characters")
+        assertTrue("-expected content" in message, "Should show deleted expected line")
+        assertTrue("+actual content" in message, "Should show inserted actual line")
+    }
+
+    @Test
+    fun `should produce readable diff for minimal CRLF reproduction`() {
+        val expected = "unchanged line\r\nexpected content\r\n"
+        val actual   = "unchanged line\r\nactual content\r\n"
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+        assertFalse('\r' in error.message!!, "Diff output must not contain raw \\r characters")
+    }
+
+    @Test
+    fun `should handle mixed CRLF and LF line endings in baseline-like content`() {
+        // Content with mixed line endings: LF for source sections, CRLF for JS output
+        fun makeBaseline(jsLine: String): String = buildString {
+            append("//// [example.ts]\n")
+            append("export const x = 1;\n")
+            append("\n")
+            append("//// [example.js]\r\n")
+            append("$jsLine\r\n")
+        }
+
+        val expected = makeBaseline("export const x = 1;")
+        val actual   = makeBaseline("export const x = 2;")
+        val error = assertFailsWith<AssertionError> {
+            actual sameAs expected
+        }
+        val message = error.message!!
+        assertFalse('\r' in message, "Diff output must not contain raw \\r characters")
+        assertTrue("-export const x = 1;" in message, "Should show the deleted line")
+        assertTrue("+export const x = 2;" in message, "Should show the inserted line")
     }
 
 }

--- a/src/commonTest/kotlin/SameAsTest.kt
+++ b/src/commonTest/kotlin/SameAsTest.kt
@@ -18,8 +18,6 @@ package com.xemantic.kotlin.test
 
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * The [sameAs] reports differences in unified diff format.
@@ -38,7 +36,7 @@ class SameAsTest {
     fun `should pass on equal HTML strings using sameAsHtml`() {
         // given
         val html = """
-            <html>
+            <html lang='en'>
             <body>
               <h1>Hello World</h1>
               <p>This is a <strong>test</strong> paragraph.</p>
@@ -59,7 +57,7 @@ class SameAsTest {
     fun `should fail and report difference on different HTML strings using sameAsHtml`() {
         // given
         val actual = /* language=html */ """
-            <html>
+            <html lang='en'>
             <body>
               <h1>Hello World</h1>
               <p>Updated paragraph.</p>
@@ -73,7 +71,7 @@ class SameAsTest {
         """.trimIndent()
 
         val expected = """
-            <html>
+            <html lang='en'>
             <body>
               <h1>Hello World</h1>
               <p>Original paragraph.</p>
@@ -2339,30 +2337,33 @@ class SameAsTest {
 
     @Test
     fun `should produce readable diff without raw CR for CRLF strings differing in content`() {
+        // given
         val expected = "unchanged line\r\nexpected content\r\n"
         val actual   = "unchanged line\r\nactual content\r\n"
-        val error = assertFailsWith<AssertionError> {
-            actual sameAs expected
-        }
-        val message = error.message!!
-        assertFalse('\r' in message, "Diff output must not contain raw \\r characters")
-        assertTrue("-expected content" in message, "Should show deleted expected line")
-        assertTrue("+actual content" in message, "Should show inserted actual line")
-    }
 
-    @Test
-    fun `should produce readable diff for minimal CRLF reproduction`() {
-        val expected = "unchanged line\r\nexpected content\r\n"
-        val actual   = "unchanged line\r\nactual content\r\n"
+        // when
         val error = assertFailsWith<AssertionError> {
             actual sameAs expected
         }
-        assertFalse('\r' in error.message!!, "Diff output must not contain raw \\r characters")
+
+        // then
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -1,2 +1,2 @@
+             unchanged line
+            -expected content
+            +actual content
+
+        """.trimIndent()
+        assert('\r' !in error.message!!)
     }
 
     @Test
     fun `should handle mixed CRLF and LF line endings in baseline-like content`() {
         // Content with mixed line endings: LF for source sections, CRLF for JS output
+        // check xemantic-typescript-compiler where this bug was initially discovered
+        // given
         fun makeBaseline(jsLine: String): String = buildString {
             append("//// [example.ts]\n")
             append("export const x = 1;\n")
@@ -2373,13 +2374,25 @@ class SameAsTest {
 
         val expected = makeBaseline("export const x = 1;")
         val actual   = makeBaseline("export const x = 2;")
+
+        // when
         val error = assertFailsWith<AssertionError> {
             actual sameAs expected
         }
-        val message = error.message!!
-        assertFalse('\r' in message, "Diff output must not contain raw \\r characters")
-        assertTrue("-export const x = 1;" in message, "Should show the deleted line")
-        assertTrue("+export const x = 2;" in message, "Should show the inserted line")
+
+        // then
+        error.message sameAs """
+            --- expected
+            +++ actual
+            @@ -2,4 +2,4 @@
+             export const x = 1;
+             
+             //// [example.js]
+            -export const x = 1;
+            +export const x = 2;
+
+        """.trimIndent()
+        assert('\r' !in error.message!!)
     }
 
 }


### PR DESCRIPTION
Strip trailing \r from each line in splitLinesForDiff so that strings with CRLF line endings produce readable unified diff output.

Previously the raw \r caused the terminal cursor to jump to column 0, overwriting the -/+ diff prefixes.

Closes #72

Generated with [Claude Code](https://claude.ai/code)